### PR TITLE
Makefile fix

### DIFF
--- a/template_configurator/templates/Makefile
+++ b/template_configurator/templates/Makefile
@@ -215,8 +215,8 @@ target/jsonld_context/%.model.context.jsonld: $(SCHEMA_DIR)/%.yaml tdir-jsonld_c
 # ---------------------------------------
 # Plain Old (PO) JSON
 # ---------------------------------------
-gen-json: $(patsubst %, $(PKG_T_JSON)/%.json, $(SCHEMA_NAMES))
-.PHONY: gen-json
+gen-jsonld: $(patsubst %, $(PKG_T_JSON)/%.json, $(SCHEMA_NAMES))
+.PHONY: gen-jsonld
 
 $(PKG_T_JSON)/%.json: target/json/%.json
 	mkdir -p $(PKG_T_JSON)


### PR DESCRIPTION
## Description
Changed target  name `gen-json` to `gen-jsonld`. Rationale:  `gen-jsonld` was referred to but not defined. `gen-json` was defined but not referred to. I assumed they might be one and the same. Fortunately for me after making this change I was able to fix an error I had (regarding `gen-jsonld` not being defined) and I was able to finally generate a linkml template in the `linkml-model-template` repository.

## Important!
This is, I think, a necessary fix to go along with this PR as well in the `linkml-model-template` repo: https://github.com/linkml/linkml-model-template/pull/14