### PR TITLE
Parse input test template files with `UTF-8` encoding

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -20,5 +20,6 @@ jobs:
       uses: dschep/install-pipenv-action@v1
 
     - name: Run tests
-      run: pipenv install --dev
-           pipenv run python -m unittest discover -p 'test_*.py'
+      run: |
+        pipenv install --dev
+        pipenv run python -m unittest discover -p 'test_*.py'

--- a/template_configurator/configure.py
+++ b/template_configurator/configure.py
@@ -110,7 +110,7 @@ class Configurator:
                 template_text = self.special_processing[fname](self, template_text)
             else:
                 template_text = template_text.format(**self.config_dict)
-            with open(target_file, 'w') as f:
+            with open(target_file, "w", encoding="utf-8") as f:
                 f.write(template_text)
             print(f"{rel_target} written")
         else:


### PR DESCRIPTION
This PR seeks to address issue #16.

Output of test command after incorporating this fix:

![image](https://user-images.githubusercontent.com/20239224/129075088-e9ccb34c-172c-4b3a-8bd7-92265d523335.png)